### PR TITLE
Fix parsing of Lint error message on windows

### DIFF
--- a/lib/linter-julia.coffee
+++ b/lib/linter-julia.coffee
@@ -23,8 +23,8 @@ doSomeMagic = (data,textEditor) ->
   lines = data.split("\n")
   for line in lines
     try
-      splittedline = line.split(":")
-      numbers = splittedline[1].split(" ")
+      splittedline = line.replace(filePath+":","").split(":")
+      numbers = splittedline[0].split(" ")
       if numbers[1] in ignore
         continue
       row_number = parseInt(numbers[0],10) - 1

--- a/lib/linter-julia.coffee
+++ b/lib/linter-julia.coffee
@@ -25,7 +25,7 @@ doSomeMagic = (data,textEditor) ->
     try
       splittedline = line.replace(filePath+":","").split(":")
       numbers = splittedline[0].split(" ")
-      if numbers[1] in ignore
+      if numbers.length < 2 || numbers[1] in ignore
         continue
       row_number = parseInt(numbers[0],10) - 1
       severity = (numbers[1])[0]


### PR DESCRIPTION
On windows the filePath includes `C:` which breaks the current `split(":")` logic which depends on the error message being in the second element of `splittedline`.  This simply removes the filename from `line` before the call to `split`, and then assumes that the error message is in the first element of `splittedline`.  This seems to work on windows.  I have not tested on mac or linux.