### PR TITLE
README: various wording/line-break tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # linter-julia
-==============
 
-This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides
-an interface to [Lint.jl](https://github.com/tonyhffong/Lint.jl). It will be
-used with files that have the “Julia” syntax.
+This linter plugin for [AtomLinter](https://atomlinter.github.io/)
+provides an interface to [Lint.jl](https://github.com/tonyhffong/Lint.jl).
+It will be used with files that have the `Julia` syntax.
 
 ![screenshot](https://raw.githubusercontent.com/TeroFrondelius/linter-julia/master/Screenshot.gif)
 
 ## Installation
-Install package through Atom or use CLI:
+
+Install the package through Atom's UI, or use the `apm` tool in the CLI:
 
 ```bash
 $ apm install linter-julia
 ```
-Note: if you have't installed [Juno](http://junolab.org/), you need to tell
-linter-julia your julia executable location (i.e. `/usr/bin/julia`). See
-Settings below.
+
+Note: if you have't installed [Juno](http://junolab.org/),
+you need to tell linter-julia where to find the julia executable
+(i.e. `/usr/bin/julia`). See Settings below.
 
 In order to use this package, you will need to install Julia and Lint.jl
 (version 0.2.6 or higher).
 To get Julia see: http://julialang.org/downloads/ and to get Lint.jl
 see: https://github.com/tonyhffong/Lint.jl#installation
-
 
 Before [Lint.jl version 0.2.6 is released](https://github.com/tonyhffong/Lint.jl/releases),
 you will need to do `Pkg.checkout("Lint")` after `Pkg.add("Lint")` command.
@@ -34,9 +34,9 @@ After the version 0.2.6 is realeased, you can do `Pkg.free("Lint")`.
 
 ## Features
 
-* By default linter-julia uses Juno's julia
-* User can give path to the julia, which they want to use for Linting
-* Ignore the messages you don't need
+* By default linter-julia uses Juno's `julia`
+* You can give a path to the `julia` executable that you want to use for Linting
+* You can ignore the messages you don't need
 
 [Issues](https://github.com/TeroFrondelius/linter-julia/issues) and [pull requests]
 (https://github.com/TeroFrondelius/linter-julia/pulls) are welcome.


### PR DESCRIPTION
* A few sentences were slightly edited, for clarity and readability
* The `====` syntax, which is redundant with the `#` prefix (both create a `<h1>`), was removed
* Some line breaks were adjusted to conform to the [semantic linebreaks](http://rhodesmill.org/brandon/2012/one-sentence-per-line/) principle
* The wording of the entries in the Features section was harmonized